### PR TITLE
Added /bigobj flag for MSVC

### DIFF
--- a/src/storage/index/CMakeLists.txt
+++ b/src/storage/index/CMakeLists.txt
@@ -4,6 +4,10 @@ add_library(kuzu_storage_index
         in_mem_hash_index.cpp
         index.cpp)
 
+if(MSVC)
+    target_compile_options(kuzu_storage_index PUBLIC "/bigobj")
+endif()
+
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_storage_index>
         PARENT_SCOPE)


### PR DESCRIPTION
I have been using kuzu(and now its forks) for a while, and have seen this issue a few times. This is a build system change that only applies to MSVC. For reference, I am using this version:

```
J:\cypherdb\build>msbuild --version
MSBuild version 17.14.23+b0019275e for .NET Framework
17.14.23.4220
```

When building with CMake and `msbuild`, I encountered the following error:

```
J:\cypherdb\src\storage\index\hash_index.cpp(1,1): error C1128: number of sections exceeded object file format limit: compile with /bigobj [J:\cypherdb\build\src\storage\index\kuzu_storage_index.vcxproj]
```

This was the only build error. After adding the change in this commit, the build finished with zero errors.